### PR TITLE
Bugfix and PIM assignments

### DIFF
--- a/_outputs.tf
+++ b/_outputs.tf
@@ -271,7 +271,7 @@ output "administrative_units" {
 # ---------------------------------------------------------
 
 locals {
-  group_types = ["TEAM", "DYN", "PERM", "APP", "AWS"]
+  group_types = ["TEAM", "DYN", "PERM", "APP"]
 }
 
 output "all_groups" {

--- a/_outputs.tf
+++ b/_outputs.tf
@@ -279,7 +279,7 @@ output "all_groups" {
 }
 
 output "groups" {
-  value = { for gt in local.group_types : gt => [ for gkey, gvalue in var.groups : gvalue.type == "DYN" ? azuread_group.groups-dynamic[gkey] : azuread_group.groups-static[gkey] if gvalue.type == gt ] }
+  value = { for gt in local.group_types : gt => [ for gkey, gvalue in var.groups : try(local.all_groups[gkey], null) if gvalue.type == gt ] }
 }
 
 # ---------------------------------------------------------

--- a/_variables.tf
+++ b/_variables.tf
@@ -245,8 +245,8 @@ variable "groups" {
 
   validation {
     # REMEMBER: If adding a new group type you should update the _outputs.tf file group_types local to include it as an output
-    condition     = alltrue([for group in var.groups : contains(["TEAM", "DYN", "PERM", "APP", "AWS"], group.type)])
-    error_message = "Group type must be either [TEAM, DYN, PERM, APP, AWS]"
+    condition     = alltrue([for group in var.groups : contains(["TEAM", "DYN", "PERM", "APP"], group.type)])
+    error_message = "Group type must be either [TEAM, DYN, PERM, APP]"
   }
 
   validation {

--- a/_variables.tf
+++ b/_variables.tf
@@ -73,6 +73,8 @@ variable "top_level_admins" {
     last_name                    = string
     usage_location               = string
     global_administrator         = bool
+    priv_role_administrator      = bool
+    priv_auth_administrator      = bool
     azure_root_administrator     = bool
     is_pim                       = optional(bool, true)
   }))
@@ -319,11 +321,10 @@ variable "role_assignments_permanent" {
   description = "Permanent role assignments."
   nullable    = true
 
-  # This is temporarily disabled as PIM is not properly supported in the Terraform AzureAD provider
-  # validation {
-  #   condition     = alltrue([for role, assignments in var.role_assignments_permanent : strcontains(role, "Reader")])
-  #   error_message = "Permant role assignments MUST contain Reader only"
-  # }
+  validation {
+    condition     = alltrue([for role, assignments in var.role_assignments_permanent : !contains(["Global Administrator", "Privileged Role Administrator", "Privileged Authentication Administrator"], role)])
+    error_message = "Role CANNOT be [Global Administrator, Privileged Role Administrator, Privileged Authentication Administrator]"
+  }
 
   validation {
     condition     = alltrue(flatten([for rakey, ravalue in var.role_assignments_permanent : flatten([for v in ravalue : contains(["user", "guest", "guest_tf", "group", "group_tf", "service_principal", "service_principal_tf", "id"], v)])]))

--- a/roleassignments.tf
+++ b/roleassignments.tf
@@ -40,19 +40,11 @@ resource "azuread_directory_role_assignment" "permanent-role-assignment" {
 # PIM
 # ---------------------------------------------------------
 
-# The below does not work properly, see - 
+resource "azuread_directory_role_eligibility_schedule_request" "pim-role-assignment" {
+  for_each = local.all_pim_role_assignments
 
-# https://github.com/hashicorp/terraform-provider-azuread/issues/1234
-# and!
-# https://github.com/hashicorp/terraform-provider-azuread/issues/1306
-# and!
-# https://github.com/hashicorp/terraform-provider-azuread/issues/1386
-
-# resource "azuread_directory_role_eligibility_schedule_request" "pim-role-assignment" {
-#   for_each = local.all_pim_role_assignments
-
-#   role_definition_id = azuread_directory_role.roles[each.value.role].template_id
-#   principal_id       = each.value.type == "id" ? each.value.principal : endswith(each.value.type, "_tf") ? local.all_tf_resources[each.value.type][each.value.principal] : local.all_users_guests_groups_sps[each.value.principal].id
-#   directory_scope_id = "/"
-#   justification      = "Assigned via IAM Azure Terraform - see code for details."
-# }
+  role_definition_id = azuread_directory_role.roles[each.value.role].template_id
+  principal_id       = each.value.type == "id" ? each.value.principal : endswith(each.value.type, "_tf") ? local.all_tf_resources[each.value.type][each.value.principal] : local.all_users_guests_groups_sps[each.value.principal].id
+  directory_scope_id = "/"
+  justification      = "Assigned via IAM Azure Terraform - see code for details."
+}

--- a/topleveladmins.tf
+++ b/topleveladmins.tf
@@ -72,14 +72,65 @@ resource "azuread_directory_role_assignment" "topleveladmin-globalreader" {
 }
 
 # ---------------------------------------------------------
-# Delegate Global Administrator Role
+# Delegate Permanent Roles
 # ---------------------------------------------------------
 
+# Global Administrator
 resource "azuread_directory_role_assignment" "topleveladmin-globaladministrator" {
   for_each = { for k, v in var.top_level_admins : k => v if v.global_administrator && v.is_pim == false } # Only delegate if global_administrator = true
 
   role_id             = azuread_directory_role.global-administrator.template_id
   principal_object_id = azuread_user.topleveladmin-users[each.key].object_id
+}
+
+# Privileged Authentication Administrator
+resource "azuread_directory_role_assignment" "topleveladmin-privauthadministrator" {
+  for_each = { for k, v in var.top_level_admins : k => v if v.priv_auth_administrator && v.is_pim == false } # Only delegate if priv_auth_administrator = true
+
+  role_id             = azuread_directory_role.privileged-authentication-administrator.template_id
+  principal_object_id = azuread_user.topleveladmin-users[each.key].object_id
+}
+
+# Privileged Role Administrator
+resource "azuread_directory_role_assignment" "topleveladmin-privroleadministrator" {
+  for_each = { for k, v in var.top_level_admins : k => v if v.priv_role_administrator && v.is_pim == false } # Only delegate if priv_role_administrator = true
+
+  role_id             = azuread_directory_role.privileged-role-administrator.template_id
+  principal_object_id = azuread_user.topleveladmin-users[each.key].object_id
+}
+
+# ---------------------------------------------------------
+# Delegate PIM Roles
+# ---------------------------------------------------------
+
+# Global Administrator
+resource "azuread_directory_role_eligibility_schedule_request" "topleveladmin-globaladministrator" {
+  for_each = { for k, v in var.top_level_admins : k => v if v.global_administrator && v.is_pim == true } # Only delegate if global_administrator = true
+
+  role_definition_id = azuread_directory_role.global-administrator.template_id
+  principal_id       = azuread_user.topleveladmin-users[each.key].object_id
+  directory_scope_id = "/"
+  justification      = "Assigned via IAM Azure Terraform - see code for details."
+}
+
+# Privileged Authentication Administrator
+resource "azuread_directory_role_eligibility_schedule_request" "topleveladmin-privauthadministrator" {
+  for_each = { for k, v in var.top_level_admins : k => v if v.priv_auth_administrator && v.is_pim == true } # Only delegate if priv_auth_administrator = true
+
+  role_definition_id = azuread_directory_role.privileged-authentication-administrator.template_id
+  principal_id       = azuread_user.topleveladmin-users[each.key].object_id
+  directory_scope_id = "/"
+  justification      = "Assigned via IAM Azure Terraform - see code for details."
+}
+
+# Privileged Role Administrator
+resource "azuread_directory_role_eligibility_schedule_request" "topleveladmin-privroleadministrator" {
+  for_each = { for k, v in var.top_level_admins : k => v if v.priv_role_administrator && v.is_pim == true } # Only delegate if priv_role_administrator = true
+
+  role_definition_id = azuread_directory_role.privileged-role-administrator.template_id
+  principal_id       = azuread_user.topleveladmin-users[each.key].object_id
+  directory_scope_id = "/"
+  justification      = "Assigned via IAM Azure Terraform - see code for details."
 }
 
 # ---------------------------------------------------------


### PR DESCRIPTION
This pull request does the following:

**Bugfix: Importing multiple groups errors groups output**
When importing multiple groups into Terraform an error was experienced as the keys for the pre staged groups could not be found as resources as they are not created yet. This has been fixed through the use of `try()`. Also a slight code efficiency has been added to use the `local.all_groups` vs the specific dynamic or static group resource directly.

**PIM Role Assignments** 
The module now supports PIM role assignments via the `azuread_directory_role_eligibility_schedule_request` resource. This is after the fix implemented as part of https://github.com/hashicorp/terraform-provider-azuread/pull/1682
NOTE: Although this is now supported in the module it cannot be used when running the module under a user principal, this is an issue documented under https://github.com/hashicorp/terraform-provider-azuread/issues/1234

**Remove the AWS group type**
This has been removed in favour of using `TEAM` or `PERM` groups for granting AWS access.